### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "cd src && python main.py"

--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ that starts with "gen_", for example: "gen_premium", now the bot will automatica
 - (you can get the emojis on Discord by typing \ before sending the emoji in chat) (an emoji ID looks something like this <:test_emoji:710171225267372144>)
 
 - If you fail to meet theese requirements the bot may raise an  error
+
+[![Run on Repl.it](https://repl.it/badge/github/hyperstore2020/Discord-Reaction-GeneratorBOT)](https://repl.it/github/hyperstore2020/Discord-Reaction-GeneratorBOT)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).